### PR TITLE
Moved location of version string.

### DIFF
--- a/eyap/__init__.py
+++ b/eyap/__init__.py
@@ -86,8 +86,6 @@ further details on usage, how to create new backends, etc.
 
 """
 
-VERSION = '0.8.8'
-
 import logging
 import doctest
 

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ def get_readme():
     return result
 
 setup(
-    name='eyap',
-    version=eyap.VERSION,
+    name='eyap',      # version is below not in eyap.__init__ since init
+    version='0.9.0',  # needs dependancies already installed for import
     description='Tools for extending yapping and comment management',
     long_description=get_readme(),
     url='http://github.com/emin63/eyap',


### PR DESCRIPTION
Previously version string was in __init__ but that cased failure to
install with pip if dependancies were not already installed.